### PR TITLE
Add web frontend and OCPP example

### DIFF
--- a/.env.dev
+++ b/.env.dev
@@ -1,0 +1,4 @@
+# Example environment file
+DATABASE_URL=sqlite:///./dev.db
+PRICE_PER_KWH=0.2
+SECRET_KEY=change_me

--- a/.env.prod
+++ b/.env.prod
@@ -1,0 +1,4 @@
+# Example environment file
+DATABASE_URL=sqlite:///./dev.db
+PRICE_PER_KWH=0.2
+SECRET_KEY=change_me

--- a/.env.test
+++ b/.env.test
@@ -1,0 +1,4 @@
+# Example environment file
+DATABASE_URL=sqlite:///./dev.db
+PRICE_PER_KWH=0.2
+SECRET_KEY=change_me

--- a/.gitignore
+++ b/.gitignore
@@ -161,4 +161,5 @@ cython_debug/
 #  be found at https://github.com/github/gitignore/blob/main/Global/JetBrains.gitignore
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
-#.idea/
+#.idea/*.db
+*.db

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 This project provides a simplified prepaid EV charging backend using FastAPI and OCPP 1.6 libraries. It demonstrates user registration, login, balance top-up and charging session tracking. Secrets and database configuration are provided through environment variables.
 
+The web application includes basic HTML pages optimised for mobile using Bootstrap. An admin panel is provided to list users and sessions. A minimal OCPP 1.6 central system example is included in `app/ocpp_server.py`.
+
 ## Setup
 
 1. Install dependencies
@@ -12,10 +14,22 @@ pip install -r requirements.txt
 
 2. Copy `.env.example` to `.env` and adjust values for your environment.
 
-3. Run the server
+3. Choose environment configuration:
+   - `.env.dev` for development (default SQLite database)
+   - `.env.test` for testing
+   - `.env.prod` for production
+   Copy the appropriate file to `.env` before starting the app.
+
+4. Run the server
 
 ```bash
 uvicorn app.main:app --reload
+```
+
+To run the OCPP central system used for charge point communication:
+
+```bash
+python app/ocpp_server.py
 ```
 
 ## Running tests
@@ -28,9 +42,9 @@ pytest
 
 ```mermaid
 graph TD
-    User--HTTP-->App((FastAPI))
-    App--DB-->Database[(SQLite/MySQL)]
-    App--WebSocket-->CentralSystem((OCPP 1.6))
+    User--HTTP-->WebApp((FastAPI + Templates))
+    WebApp--DB-->Database[(SQLite/MySQL)]
+    WebApp--WebSocket-->CentralSystem((OCPP 1.6))
     CentralSystem--WebSocket-->ChargePoint
 ```
 

--- a/app/ocpp_server.py
+++ b/app/ocpp_server.py
@@ -1,0 +1,70 @@
+import asyncio
+import logging
+import os
+
+from ocpp.routing import on
+from ocpp.v16 import ChargePoint as CP
+from ocpp.v16 import call_result
+from ocpp.v16.enums import RegistrationStatus
+from websockets.server import serve
+
+from .database import SessionLocal
+from .models import ChargingSession, User
+
+logging.basicConfig(level=logging.INFO)
+
+PRICE_PER_KWH = float(os.getenv("PRICE_PER_KWH", "0.2"))
+
+
+class ChargePoint(CP):
+    async def send_boot_notification(self):
+        request = call_result.BootNotification(
+            current_time="2025-01-01T00:00:00Z", interval=10, status=RegistrationStatus.accepted
+        )
+        await self.call(request)
+
+    @on("StartTransaction")
+    async def on_start(self, connector_id, id_tag, timestamp, meter_start, reservation_id=None, **kwargs):
+        db = SessionLocal()
+        user = db.query(User).filter(User.username == id_tag).first()
+        if not user or user.balance <= 0:
+            return call_result.StartTransactionPayload(id_tag_info={"status": "Invalid"}, transaction_id=0)
+        session = ChargingSession(user_id=user.id)
+        db.add(session)
+        db.commit()
+        db.refresh(session)
+        db.close()
+        return call_result.StartTransactionPayload(
+            transaction_id=session.id, id_tag_info={"status": "Accepted"}
+        )
+
+    @on("StopTransaction")
+    async def on_stop(self, meter_stop, timestamp, transaction_id, id_tag, **kwargs):
+        db = SessionLocal()
+        session = db.query(ChargingSession).filter(ChargingSession.id == transaction_id).first()
+        user = session.user
+        energy = (meter_stop - (session.energy or 0)) / 1000
+        cost = energy * PRICE_PER_KWH
+        if user.balance < cost:
+            session.active = False
+            db.commit()
+            db.close()
+            return call_result.StopTransactionPayload(id_tag_info={"status": "Expired"})
+        user.balance -= cost
+        session.energy = energy
+        session.active = False
+        db.commit()
+        db.close()
+        return call_result.StopTransactionPayload(id_tag_info={"status": "Accepted"})
+
+
+async def main():
+    async def handler(websocket):
+        cp = ChargePoint('CP001', websocket)
+        await cp.start()
+    async with serve(handler, "0.0.0.0", 9000):
+        await asyncio.Future()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/app/templates/admin.html
+++ b/app/templates/admin.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Admin Panel</h2>
+<table class="table">
+  <thead><tr><th>User</th><th>Balance</th><th>Sessions</th></tr></thead>
+  <tbody>
+    {% for u in users %}
+    <tr><td>{{ u.username }}</td><td>{{ u.balance }}</td><td>{{ u.sessions|length }}</td></tr>
+    {% endfor %}
+  </tbody>
+</table>
+<a href="/dashboard" class="btn btn-primary">Back</a>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.1/dist/css/bootstrap.min.css">
+    <title>{{ title or "EV Charging" }}</title>
+</head>
+<body>
+<nav class="navbar navbar-expand-lg navbar-light bg-light">
+  <div class="container-fluid">
+    <a class="navbar-brand" href="/">EV Charging</a>
+  </div>
+</nav>
+<div class="container mt-4">
+{% block content %}{% endblock %}
+</div>
+</body>
+</html>

--- a/app/templates/dashboard.html
+++ b/app/templates/dashboard.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Hello, {{ user.username }}!</h2>
+<p>Balance: {{ user.balance }} EUR</p>
+<form method="post" action="/topup" class="mb-3">
+  <div class="input-group">
+    <input type="number" step="0.01" class="form-control" name="amount" placeholder="Top up amount" required>
+    <button class="btn btn-secondary" type="submit">Top up</button>
+  </div>
+</form>
+<a href="/session/start" class="btn btn-success me-2">Start Session</a>
+<a href="/logout" class="btn btn-danger">Logout</a>
+{% endblock %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,0 +1,6 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Welcome to EV Charging</h2>
+<a href="/signup" class="btn btn-primary me-2">Sign Up</a>
+<a href="/login" class="btn btn-secondary">Login</a>
+{% endblock %}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Login</h2>
+<form method="post" action="/login">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Login</button>
+</form>
+{% endblock %}

--- a/app/templates/signup.html
+++ b/app/templates/signup.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Sign Up</h2>
+<form method="post" action="/signup">
+  <div class="mb-3">
+    <label for="username" class="form-label">Username</label>
+    <input type="text" class="form-control" id="username" name="username" required>
+  </div>
+  <div class="mb-3">
+    <label for="password" class="form-label">Password</label>
+    <input type="password" class="form-control" id="password" name="password" required>
+  </div>
+  <button type="submit" class="btn btn-primary">Sign Up</button>
+</form>
+{% endblock %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ pydantic
 pytest
 httpx
 ocpp==0.7.2
+jinja2

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,11 +1,17 @@
 from fastapi.testclient import TestClient
+import os
+
+TEST_DB = "test.db"
+if os.path.exists(TEST_DB):
+    os.remove(TEST_DB)
+os.environ["DATABASE_URL"] = f"sqlite:///./{TEST_DB}"
 from app.main import app
 
 client = TestClient(app)
 
 
 def signup_user(username: str, password: str):
-    return client.post("/signup", data={"username": username, "password": password})
+    return client.post("/api/signup", data={"username": username, "password": password})
 
 
 def login_user(username: str, password: str):
@@ -26,11 +32,11 @@ def test_topup_and_session():
     login = login_user("bob", "pwd")
     token = login.json()["access_token"]
     headers = {"Authorization": f"Bearer {token}"}
-    topup = client.post("/topup", params={"amount": 5}, headers=headers)
+    topup = client.post("/api/topup", params={"amount": 5}, headers=headers)
     assert topup.status_code == 200
-    session_start = client.post("/session/start", headers=headers)
+    session_start = client.post("/api/session/start", headers=headers)
     assert session_start.status_code == 200
     session_id = session_start.json()["session_id"]
-    stop = client.post("/session/stop", params={"session_id": session_id, "energy": 1}, headers=headers)
+    stop = client.post("/api/session/stop", params={"session_id": session_id, "energy": 1}, headers=headers)
     assert stop.status_code == 200
     assert stop.json()["remaining_balance"] < 5


### PR DESCRIPTION
## Summary
- add minimal Bootstrap web UI for signup, login and admin views
- support HTML forms along existing JSON API endpoints
- provide simple OCPP 1.6 central system example
- add environment templates for dev/test/prod and document them
- update tests to use API endpoints and isolated DB

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684eb907c668832b88986171c6e8490e